### PR TITLE
Use abspath instead of join for absolute path

### DIFF
--- a/lama_cleaner/file_manager/file_manager.py
+++ b/lama_cleaner/file_manager/file_manager.py
@@ -99,7 +99,7 @@ class FileManager:
         if os.path.isabs(path):
             return path
         else:
-            return os.path.join(self.app.root_path, path)
+            return os.path.abspath(path)
 
     @property
     def thumbnail_directory(self):
@@ -108,7 +108,7 @@ class FileManager:
         if os.path.isabs(path):
             return path
         else:
-            return os.path.join(self.app.root_path, path)
+            return os.path.abspath(path)
 
     @property
     def root_url(self):


### PR DESCRIPTION
Use `abspath` to get the absolute path instead of `join` with the `root_path` as this would lead to the wrong path when a user inputs a relative path.