### PR TITLE
the wrong param name of "upscale"

### DIFF
--- a/web_app/src/lib/api.ts
+++ b/web_app/src/lib/api.ts
@@ -135,7 +135,7 @@ export async function runPlugin(
     body: JSON.stringify({
       name,
       image: imageBase64,
-      upscale,
+      scale:upscale,
       clicks,
     }),
   })


### PR DESCRIPTION
I found that on the server side, the field name accepted by the API is "scale", but the field name used in requests sent by the web frontend is "upscale", causing the server side to never receive this field, and all requests end up using the default value(2.0).