### PR TITLE
Update imghdr to undeprecated package

### DIFF
--- a/iopaint/helper.py
+++ b/iopaint/helper.py
@@ -1,5 +1,5 @@
 import base64
-import imghdr
+import filetype
 import io
 import os
 import sys
@@ -298,7 +298,7 @@ def is_mac():
 
 
 def get_image_ext(img_bytes):
-    w = imghdr.what("", img_bytes)
+    w = filetype.guess_extension(img_bytes)
     if w is None:
         w = "jpeg"
     return w

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ omegaconf
 easydict
 gradio==4.21.0
 typer-config==1.4.0
-
+filetype
 Pillow==9.5.0 # for AnyText


### PR DESCRIPTION
IOPaint currently uses Python's built-in imghdr module but imghdr was deprecated in Python 3.11 and removed in 3.13. So it's probably a good idea to replace imghdr with one of the replacement 3rd-party libraries (I used filetype and added it to the requirements.txt)